### PR TITLE
(test) add travis config, (cleanup) add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+
 # Logs
 logs
 *.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+          - node


### PR DESCRIPTION
Travis CI is set to use the latest Node.js version. Node LTS version 6 just came out, so looking to stay up to date
